### PR TITLE
Us19 update campaign item

### DIFF
--- a/app/controllers/api/v1/campaign_items_controller.rb
+++ b/app/controllers/api/v1/campaign_items_controller.rb
@@ -5,6 +5,12 @@ class Api::V1::CampaignItemsController < ApplicationController
     render json: CampaignItemSerializer.new(campaign_item), status: 201
   end
 
+  def update
+    campaign_item = CampaignItem.find(params[:id])
+    campaign_item.update!(campaign_item_params)
+    render json: CampaignItemSerializer.new(campaign_item), status: 200
+  end
+
   private
 
   def campaign_item_params

--- a/spec/requests/api/v1/campaign_items_request_spec.rb
+++ b/spec/requests/api/v1/campaign_items_request_spec.rb
@@ -24,5 +24,109 @@ RSpec.describe "campaign items API" do
         expect(created_campaign_item.quantity_owned).to eq(0)
       end
     end
+
+    describe "sad paths" do
+      before(:each) do
+        @item1 = create(:item)
+        @campaign1 = create(:campaign)
+      end
+
+      it "returns a 400 status and error message when the campaign_id doesn't exist" do 
+        campaign_item_params = ({ campaign_id: 123123,
+                                  item_id: @item1.id,
+                                  quantity_owned: 0 })
+  
+        headers = {"CONTENT_TYPE" => "application/json"}
+      
+        post "/api/v1/campaign_items", headers: headers, params: JSON.generate(campaign_item: campaign_item_params)
+  
+        expect(response).to_not be_successful
+        expect(response.status).to eq(422)
+  
+        data = JSON.parse(response.body, symbolize_names: true)
+        
+        expect(data[:errors]).to be_an(Array)
+        expect(data[:errors].first[:status]).to eq("422")
+        expect(data[:errors].first[:title]).to eq("Validation failed: Campaign must exist")
+      end
+
+      it "returns a 400 status and error message when missing the item_id attribute" do 
+        campaign_item_params = ({ campaign_id: @campaign1.id,
+                                  item_id: "",
+                                  quantity_owned: 0 })
+  
+        headers = {"CONTENT_TYPE" => "application/json"}
+      
+        post "/api/v1/campaign_items", headers: headers, params: JSON.generate(campaign_item: campaign_item_params)
+  
+        expect(response).to_not be_successful
+        expect(response.status).to eq(422)
+  
+        data = JSON.parse(response.body, symbolize_names: true)
+        
+        expect(data[:errors]).to be_an(Array)
+        expect(data[:errors].first[:status]).to eq("422")
+        expect(data[:errors].first[:title]).to eq("Validation failed: Item must exist, Item can't be blank")
+      end
+    end
+  end
+
+  describe "campaign item update" do 
+    describe "happy path" do
+      before(:each) do
+        @item1 = create(:item)
+        @campaign1 = create(:campaign)
+        @campaign_item1 = create(:campaign_item, campaign_id: @campaign1.id, item_id: @item1.id, quantity_owned: 1)
+      end
+
+      it "updates a campaign_items attributes and returns the campaign_item" do
+        id = @campaign_item1.id
+        original_campaign_item = CampaignItem.last
+
+        # the below would represent updating the wood and villagers field while leaving the rest as is
+        campaign_item_params = { campaign_id: @campaign1.id, 
+                                 item_id: @item1.id, 
+                                 quantity_owned: 10 
+        }
+
+        headers = {"CONTENT_TYPE" => "application/json"}
+        
+        patch "/api/v1/campaign_items/#{id}", headers: headers, params: JSON.generate({campaign_item: campaign_item_params})
+
+        campaign_item = JSON.parse(response.body, symbolize_names: true)[:data]
+
+        expect(response).to be_successful
+        expect(campaign_item[:attributes][:campaign_id]).to eq(original_campaign_item.campaign_id)
+        expect(campaign_item[:attributes][:item_id]).to eq(original_campaign_item.item_id)
+        expect(campaign_item[:attributes][:quantity_owned]).to eq(10)
+      end
+    end
+
+    describe "sad path" do
+      before(:each) do
+        @item1 = create(:item)
+        @campaign1 = create(:campaign)
+      end
+
+      it "returns a 404 status and error message when an invalid campaign_item id is passed in" do 
+        campaign_item_params = { campaign_id: @campaign1.id, 
+        item_id: @item1.id, 
+        quantity_owned: 10 
+      }
+
+        headers = {"CONTENT_TYPE" => "application/json"}
+
+        patch "/api/v1/campaign_items/123123", headers: headers, params: JSON.generate({campaign_item: campaign_item_params})
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(404)
+  
+        data = JSON.parse(response.body, symbolize_names: true)
+        
+        expect(data[:errors]).to be_an(Array)
+        expect(data[:errors].first[:status]).to eq("404")
+        expect(data[:errors].first[:title]).to eq("Couldn't find CampaignItem with 'id'=123123")
+      end
+    end
   end
 end


### PR DESCRIPTION
- This endpoint follows the pattern of `PATCH /api/v0/campaign_items/:id` and can pass an integer to the attribute quantity_owned via the body of the request.
- This endpoint updates an existing campaign item with any parameters sent in via the body.
- If an invalid campaign id or an invalid item id is passed in, a 404 status code as well as a descriptive message should be sent back with the response.
- If a campaign id and/or an item id are not passed in, a 400 status code as well as a descriptive message should be sent back with the response.

closes #19 
closes #18 

