### PR TITLE
Feat/48 advance week

### DIFF
--- a/app/controllers/api/v1/campaigns_controller.rb
+++ b/app/controllers/api/v1/campaigns_controller.rb
@@ -30,6 +30,72 @@ class Api::V1::CampaignsController < ApplicationController
                   :monster_parts, 
                   :stone, 
                   :wood, 
-                  :villagers)
+                  :villagers
+                 )
+  end
+
+  def management_form_params
+    params.require(:campaign)
+          .permit(:campaign_id, :week, :animal_products, :cloth, :farmed_goods, :food, :foraged_goods, 
+                  :metal, :monster_parts, :stone, :wood, :light_armor, :medium_armor, 
+                  :heavy_armor, :simple_weapon, :martial_weapon, :ammunition, :adventuring_supplies, 
+                  :assassins_blood, :malice, :midnight_tears, :serpent_venom, :truth_serum, 
+                  :oil_of_slipperiness, :potion_of_climbing, :potion_of_healing, :potion_of_water_breathing, 
+                  :barge, :coracle, :double_hulled_sailing_canoe, :keelboat, :raft, 
+                  :single_hulled_sailing_canoe, :ballista, :cabin, :magical_defenses, :storage
+                 )
+  end
+
+  def update_campaign_resources(campaign, management_form)
+    resource_attributes = %i[animal_products cloth farmed_goods food foraged_goods metal monster_parts stone wood]
+
+    resource_attributes.each do |attr|
+      next if management_form[attr].zero?
+
+      campaign[attr] += (management_form[attr] / 10)
+    end
+
+    campaign.save!
+  end
+
+  def subtract_item_costs(campaign, management_form)
+    management_form.attributes.each do |key, value|
+      next unless value.is_a?(Integer) && value > 0
+
+      item = Item.find_by(name: key.humanize)
+      next unless item
+
+      item_cost_attributes = %i[animal_products_cost cloth_cost farmed_goods_cost food_cost foraged_goods_cost metal_cost stone_cost wood_cost monster_parts_cost]
+
+      item_cost_attributes.each do |cost_attr|
+        resource_attr = cost_attr.to_s.gsub('_cost', '').to_sym
+        campaign[resource_attr] -= item[cost_attr] * value if campaign[resource_attr]
+      end
+    end
+
+    campaign.save!
+  end
+
+  def create_new_management_form(campaign)
+    ManagementForm.create!(
+      campaign_id: campaign.id,
+      week: campaign.week
+    )
+  end
+
+  def update_campaign_items_quantity(management_form)
+    item_attributes = %i[light_armor medium_armor heavy_armor simple_weapon martial_weapon ammunition adventuring_supplies assassins_blood malice midnight_tears serpent_venom truth_serum oil_of_slipperiness potion_of_climbing potion_of_healing potion_of_water_breathing barge coracle double_hulled_sailing_canoe keelboat raft single_hulled_sailing_canoe ballista cabin magical_defenses storage]
+
+    item_attributes.each do |attr|
+      item = Item.find_by(name: attr.to_s.humanize)
+      next unless item
+      item_id = item.id
+      campaign_id = management_form.campaign_id
+      
+      campaign_item = CampaignItem.find_by(item_id: item_id, campaign_id: campaign_id)
+
+      prev_quant_owned = campaign_item.quantity_owned
+      campaign_item.update!(quantity_owned: prev_quant_owned += management_form[attr])
+    end
   end
 end

--- a/app/controllers/api/v1/campaigns_controller.rb
+++ b/app/controllers/api/v1/campaigns_controller.rb
@@ -16,6 +16,21 @@ class Api::V1::CampaignsController < ApplicationController
     render json: CampaignSerializer.new(campaign), status: 200
   end
 
+  def advance_week
+    campaign = Campaign.find(params[:campaign_id])
+    management_form = ManagementForm.new(management_form_params)
+    if management_form.save
+      campaign.update!(week: campaign.week + 1)
+      update_campaign_resources(campaign, management_form)
+      subtract_item_costs(campaign, management_form)
+      create_new_management_form(campaign)
+      update_campaign_items_quantity(management_form)
+      render json: CampaignSerializer.new(campaign), status: 200
+    else
+      render json: { error: management_form.errors.full_messages }, status: 422
+    end
+  end
+
   private
   def campaign_params
     params.require(:campaign)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :characters, only: [:show, :create]
-      resources :campaigns, only: [:show, :create, :update] 
+      resources :campaigns, only: [:show, :create, :update] do
+        post :advance_week
+      end
       resources :items, only: [:index, :show]
       resources :management_forms, only: [:update]
       resources :campaign_items, only: [:create, :update]

--- a/spec/requests/api/v1/campaigns_request_spec.rb
+++ b/spec/requests/api/v1/campaigns_request_spec.rb
@@ -258,4 +258,63 @@ RSpec.describe "Campaigns API" do
       expect(data[:errors].first[:title]).to eq("Validation failed: Wood must be an integer")
     end
   end
+
+  describe "Campaign Advance Week" do
+    it "..." do
+      @campaign = create(:campaign, wood: 20, metal: 20, animal_products: 20, week: 2)
+      @management_form = create(:management_form, campaign: @campaign, week: 2)
+
+      params = {
+        campaign_id: @campaign.id,
+        week: @campaign.week,
+        animal_products: 20,
+        cloth: 30,
+        farmed_goods: 10,
+        food: 0,
+        foraged_goods: 0,
+        metal: 0,
+        monster_parts: 0,
+        stone: 0,
+        wood: 10,
+        light_armor: 1,
+        medium_armor: 1,
+        heavy_armor: 0,
+        simple_weapon: 0,
+        martial_weapon: 0,
+        ammunition: 0,
+        adventuring_supplies: 0,
+        assassins_blood: 0,
+        malice: 0,
+        midnight_tears: 0,
+        serpent_venom: 0,
+        truth_serum: 0,
+        oil_of_slipperiness: 0,
+        potion_of_climbing: 0,
+        potion_of_healing: 0,
+        potion_of_water_breathing: 0,
+        barge: 0,
+        coracle: 0,
+        double_hulled_sailing_canoe: 0,
+        keelboat: 0,
+        raft: 1,
+        single_hulled_sailing_canoe: 0,
+        ballista: 0,
+        cabin: 0,
+        magical_defenses: 0,
+        storage: 0
+        }
+
+      headers = {"CONTENT_TYPE" => "application/json"}
+
+      post "/api/v1/campaigns/#{@campaign.id}/advance_week", headers: headers, params: JSON.generate({campaign: params})
+
+      campaign = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(response).to be_successful
+      expect(campaign[:attributes][:name]).to eq(original_campaign.name)
+      expect(campaign[:attributes][:stone]).to eq(12)
+      expect(campaign[:attributes][:wood]).to eq(15)
+      expect(campaign[:attributes][:villagers]).to eq(120)
+    end
+  end
 end


### PR DESCRIPTION
- Created custom endpoint for advance week button.
- Advance_week controller handles the following actions:

1. Add one to the week value of the campaign that the management_form belongs to
2. Take the resource values from the management_form submission, divide those values by 10 (if not 0) and add that number to the corresponding attribute on the campaign
3. Take the resource cost for any item with a quantity greater than 0 from the management_form, calculate how many resources are needed to craft it by referencing the Item table (which contains the resource cost for each item), and then subtract those amounts from the corresponding resource attribute on the campaign.
4. Create a new management_form that has the current campaign as the campaign_id, the updated week as the week, and the resource values from the campaign as the resource quantities.

- Testing could likely be improved and a refactor is definitely needed, but I think it handles all of the logic we need it to at the moment. 

Close #48 