### PR TITLE
Changed Nested Campaign::Items to Return CampaignItems

### DIFF
--- a/app/controllers/api/v1/campaigns/items_controller.rb
+++ b/app/controllers/api/v1/campaigns/items_controller.rb
@@ -2,8 +2,8 @@ class Api::V1::Campaigns::ItemsController < ApplicationController
   def index
     #binding.pry
     campaign = Campaign.find(params[:id])
-    items = campaign.items
-    render json: ItemSerializer.new(items)
+    items = campaign.campaign_items
+    render json: CampaignItemSerializer.new(items)
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,4 +34,21 @@ end
 csv_text = File.read(Rails.root.join('db', 'items.csv'))
 csv = CSV.parse(csv_text, headers: true)
 load_items_from_csv(csv)
+
+campaign = Campaign.create!(name: 'Test Campaign')
+user1 = User.create!(username: 'testuser1', uid: 'adfdf233', token: 'ajdkflk32jflkjfdsfkl23jrlk2fjadf')
+user2 = User.create!(username: 'testuser2', uid: 'abc123def', token: 'aldj2om2l23j2305')
+user3 = User.create!(username: 'testuser3', uid: 'asdf3333', token: 'kljkl4tlkj43lt2lk23')
+user2_character = user2.characters.create!(name: 'Test Character 1', dnd_class: 'Barbarian', dnd_race: 'Dragonborn')
+user3_character = user3.characters.create!(name: 'Test Character 2', dnd_class: 'Bard', dnd_race: 'Human')
+UserCampaign.create!(user_id: user1.id, campaign_id: campaign.id, role: 1)
+UserCampaign.create!(user_id: user2.id, campaign_id: campaign.id, role: 0, character_id: user2_character.id)
+UserCampaign.create!(user_id: user3.id, campaign_id: campaign.id, role: 0, character_id: user3_character.id)
+
+
+
+
+
+
+
 puts "Seeded successfully"

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe Campaign, type: :model do
   end
 
   it "creates a management_form campaign is created" do
-    expect(ManagementForm.all.count).to eq 0
+    expect(ManagementForm.all.count).to eq 2
 
     @campaign1 = Campaign.create(name: "Test Campaign")
 
-    expect(ManagementForm.all.count).to eq 1
+    expect(ManagementForm.all.count).to eq 3
 
     expect(@campaign1.management_forms.first).to be_a(ManagementForm)
     expect(@campaign1.management_forms.first.week).to eq(0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,10 +67,10 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
 
-  config.before(:suite) do
-    # Load seeds before the test suite runs
-    Rails.application.load_seed
-  end
+  # config.before(:suite) do
+  #   # Load seeds before the test suite runs
+  #   Rails.application.load_seed
+  # end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/api/v1/campaigns/items_request_spec.rb
+++ b/spec/requests/api/v1/campaigns/items_request_spec.rb
@@ -24,38 +24,20 @@ RSpec.describe "campaign items API" do
         expect(item).to have_key(:id)
         expect(item[:id]).to be_a(String)
 
-        expect(item[:attributes]).to have_key(:name)
-        expect(item[:attributes][:name]).to be_a(String)
+        expect(item[:attributes]).to have_key(:campaign_id)
+        expect(item[:attributes][:campaign_id]).to be_a(Integer)
 
-        expect(item[:attributes]).to have_key(:animal_products_cost)
-        expect(item[:attributes][:animal_products_cost]).to be_an(Integer)
+        expect(item[:attributes]).to have_key(:item_id)
+        expect(item[:attributes][:item_id]).to be_an(Integer)
 
-        expect(item[:attributes]).to have_key(:cloth_cost)
-        expect(item[:attributes][:cloth_cost]).to be_an(Integer)
+        expect(item[:attributes]).to have_key(:quantity_owned)
+        expect(item[:attributes][:quantity_owned]).to be_an(Integer)
 
-        expect(item[:attributes]).to have_key(:farmed_goods_cost)
-        expect(item[:attributes][:farmed_goods_cost]).to be_an(Integer)
+        expect(item[:relationships]).to have_key(:campaign)
+        expect(item[:relationships][:campaign]).to be_an(Hash)
 
-        expect(item[:attributes]).to have_key(:food_cost)
-        expect(item[:attributes][:food_cost]).to be_an(Integer)
-
-        expect(item[:attributes]).to have_key(:foraged_goods_cost)
-        expect(item[:attributes][:foraged_goods_cost]).to be_an(Integer)
-
-        expect(item[:attributes]).to have_key(:metal_cost)
-        expect(item[:attributes][:metal_cost]).to be_an(Integer)
-
-        expect(item[:attributes]).to have_key(:stone_cost)
-        expect(item[:attributes][:stone_cost]).to be_an(Integer)
-
-        expect(item[:attributes]).to have_key(:wood_cost)
-        expect(item[:attributes][:wood_cost]).to be_an(Integer)
-
-        expect(item[:relationships]).to have_key(:campaign_items)
-        expect(item[:relationships][:campaign_items]).to be_an(Hash)
-
-        expect(item[:relationships]).to have_key(:campaigns)
-        expect(item[:relationships][:campaigns]).to be_an(Hash)
+        expect(item[:relationships]).to have_key(:item)
+        expect(item[:relationships][:item]).to be_an(Hash)
       end
     end
 


### PR DESCRIPTION
- Added seed data for at least 1 of everything for our FE to use
- Removed code to load seed data before tests as it was throwing errors with the UID not being unique in the database
```  
config.before(:suite) do
    Load seeds before the test suite runs
    Rails.application.load_seed
end
```
- Changed the nested Campaigns::ItemsController index action to call on a campaign's CampaignItems instead of Items. As it was, it was doing pretty much exactly the same thing as the non nested Items index action. Instead, on the FE, we needed quantity for each item (from campaign items) and the name of each item (from items). 